### PR TITLE
Fix localdb for user services

### DIFF
--- a/api-gateway/default.conf
+++ b/api-gateway/default.conf
@@ -94,15 +94,6 @@ server {
         }
     }
 
-    # MongoDB Express Admin Interface (if localdb profile is used)
-    # location /admin/ {
-    #     proxy_pass http://mongo-express:8081/;
-    #     proxy_set_header Host $host;
-    #     proxy_set_header X-Real-IP $remote_addr;
-    #     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-    #     proxy_set_header X-Forwarded-Proto $scheme;
-    # }
-
     # Health check endpoint
     location /health {
         access_log off;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -50,6 +50,7 @@ services:
       - ./user-service/.env # Environment variables for user-service
     environment:
       - NODE_ENV=production # Set Node.js to production mode
+      - DB_LOCAL_URI=mongodb://root:example@mongodb-user-services:27017 # Override for container
   
   ### NOTE: LOCAL DATABASE SERVICES YET TO BE TESTED BY ME DO NOT USE YET ###
 
@@ -57,6 +58,8 @@ services:
   mongodb-user-services:
     image: mongo:7.0.12
     container_name: peerprep-mongodb-user-services
+    ports:
+      - "27017:27017" # Expose MongoDB port to host
     volumes:
       - mongodb-data-user-services:/data/db # Persistent data storage
     env_file:
@@ -68,8 +71,8 @@ services:
   mongo-express:
     image: mongo-express:1.0.2
     container_name: peerprep-mongo-express
-    expose:
-      - "8081" # Internal port only - accessed via API Gateway at /admin/
+    ports:
+      - "8081:8081" # Expose admin interface on host port 8081
     env_file:
       - ./mongo-express/.env # Connection settings
     depends_on:

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "build:frontend": "cd frontend && npm run build",
     "build:user-service": "echo 'No build step for user-service'",
     "install:all": "npm install && cd frontend && npm install && cd ../user-service && npm install",
-    "clean": "cd frontend && rm -rf node_modules && cd ../user-service && rm -rf node_modules && rm -rf node_modules"
+    "clean": "cd frontend && rm -rf node_modules && cd ../user-service && rm -rf node_modules && rm -rf node_modules",
+    "localdb": "docker-compose up mongodb-user-services mongo-express -d"
   },
   "devDependencies": {
     "concurrently": "^8.2.2"


### PR DESCRIPTION
To be able to use local mongo db do the following steps

1. update user service .env file 
 - DB_LOCAL_URI=mongodb://root:example@localhost:27017
 - ENV=LOCAL

2. on development do `npm run local db` before doing `npm run dev`
3. on docker do `docker-compose --profile localdb up`
4. to clean up do  `docker-compose --profile localdb down`

Please note that normal docker compose down won't clean up the database and may cause some errors in future as i given it profile localdb for us to swap between local and cloud db

To swap back to cloud in future change .env file to ENV=PROD
