### PR TITLE
Dispel any email change request when password is changed

### DIFF
--- a/user-service/controller/user-controller.js
+++ b/user-service/controller/user-controller.js
@@ -292,6 +292,12 @@ export async function updateUserPassword(req, res) {
       });
     }
 
+    // Delete any pending email-change verification records when pasword changes
+    // This ensures that old email change requests are cleared when user updates their password
+    // this is needed as the security notice email asked user to change password immediately
+    // if they did not initiate the change themselves
+    await _deleteUserVerifyRecordByUserId(userId);
+
     // Hash new password
     const salt = bcrypt.genSaltSync(10);
     const hashedPassword = bcrypt.hashSync(newPassword, salt);


### PR DESCRIPTION
as per title.

it is needed because i send security notice asking them to change pw
so changing pw is a sign that the email change req is not by them
<img width="1364" height="1140" alt="image" src="https://github.com/user-attachments/assets/eeaae138-9010-4bd1-bc3b-12037be42853" />
